### PR TITLE
Backfill missing lab metadata (12 files)

### DIFF
--- a/Instructions/Labs/LAB[MB-230]_M00Lab00_Dynamics_365_Labs.md
+++ b/Instructions/Labs/LAB[MB-230]_M00Lab00_Dynamics_365_Labs.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab: Validate lab environment'
-    module: 'Module 0: Configure Dynamics 365 Customer Service'
+  title: 'Lab: Validate lab environment'
+  module: 'Module 0: Configure Dynamics 365 Customer Service'
+  description: In this Module 0 lab, you will validate that your classroom tenant is working as expected. You will access your individual credentials, record your "alias", and open the Dynamics 365 model-driven application that we will be using throughout the course. This exercise should take approximately 10 minutes to complete.
+  duration: 10 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 # Practice Lab - Validate lab environment

--- a/Instructions/Labs/LAB[MB-230]_M01Lab01_Creating_Cases.md
+++ b/Instructions/Labs/LAB[MB-230]_M01Lab01_Creating_Cases.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Creating cases'
-    module: 'Module 1: Case Management'
+  title: 'Lab: Creating cases'
+  module: 'Module 1: Case Management'
+  description: You are a customer service manager at City Power & Light who has been tasked with trying the new case functionality before rolling it out to your users. In this lab, you will create new customer cases and create a phone calls associated with the cases. This exercise should take approximately 20 minutes to complete.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Creating cases

--- a/Instructions/Labs/LAB[MB-230]_M01Lab02_Creating_Queues.md
+++ b/Instructions/Labs/LAB[MB-230]_M01Lab02_Creating_Queues.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Creating queues'
-    module: 'Module 1: Case Management'
+  title: 'Lab: Creating queues'
+  module: 'Module 1: Case Management'
+  description: You are a customer service manager at City Power & Light. You need to create queues for the customer service representatives to use for processing cases. In this lab, you will create a create multiple queues and add cases to activities to queues. This exercise should take approximately 20 minutes to complete.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Queues

--- a/Instructions/Labs/LAB[MB-230]_M01Lab03_Resolving_Cases.md
+++ b/Instructions/Labs/LAB[MB-230]_M01Lab03_Resolving_Cases.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Resolving cases'
-    module: 'Module 1: Case Management'
+  title: 'Lab: Resolving cases'
+  module: 'Module 1: Case Management'
+  description: You are a customer service manager at City Power & Light who has been tasked with trying the new case resolution and reactivation functionality before rolling it out to your users. In this lab, you will resolve a case and reactive that case. This exercise should take approximately 15 minutes to complete.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Resolving cases

--- a/Instructions/Labs/LAB[MB-230]_M01Lab04_Route_Cases.md
+++ b/Instructions/Labs/LAB[MB-230]_M01Lab04_Route_Cases.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Routing cases'
-    module: 'Module 1: Case Management'
+  title: 'Lab: Routing cases'
+  module: 'Module 1: Case Management'
+  description: You are a customer service manager at City Power & Light who has been tasked with trying the new case routing functionality before rolling it out to your users. In this lab, you will create record creation rules, and case routing rules and test how they work. This exercise should take approximately 20 minutes to complete.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Routing cases

--- a/Instructions/Labs/LAB[MB-230]_M02Lab01_Entitlements_and_Templates.md
+++ b/Instructions/Labs/LAB[MB-230]_M02Lab01_Entitlements_and_Templates.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Service Level Agreements'
-    module: 'Module 2: Service Level Agreements and Knowledge Management'
+  title: 'Lab: Service Level Agreements'
+  module: 'Module 2: Service Level Agreements and Knowledge Management'
+  description: In this task, you will configure the settings for service level agreements.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Service Level Agreements

--- a/Instructions/Labs/LAB[MB-230]_M02Lab02_Create_knowledge_articles.md
+++ b/Instructions/Labs/LAB[MB-230]_M02Lab02_Create_knowledge_articles.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab: Create knowledge articles'
-    module: 'Module 2: Service Level Agreements and Knowledge Management'
+  title: 'Lab: Create knowledge articles'
+  module: 'Module 2: Service Level Agreements and Knowledge Management'
+  description: As a customer care coordinator at City Power & Light, you are responsible for instructing the customer service team and providing them with troubleshooting articles to support case resolution. You need to create a knowledge article within Dynamics 365 for Customer Service. In this lab, you will create a knowledge article, walk through the publishing process and then revise that article. This exercise should take approximately 15 minutes to complete.
+  duration: 15 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 # Practice Lab – Knowledge management

--- a/Instructions/Labs/LAB[MB-230]_M03Lab01_Customer_Service_Workspace.md
+++ b/Instructions/Labs/LAB[MB-230]_M03Lab01_Customer_Service_Workspace.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Customer Service workspace'
-    module: 'Module 3: Customer Service workspaces'
+  title: 'Lab: Customer Service workspace'
+  module: 'Module 3: Customer Service workspaces'
+  description: You are a customer service manager at City Power & Light who has been tasked with configuring the Customer Service workspace before rolling it out to your users. In this lab, you will explore how the the Customer Service workspace works. This exercise should take approximately 10 minutes to complete.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Customer Service workspace

--- a/Instructions/Labs/LAB[MB-230]_M03Lab02_AgentExpProfile.md
+++ b/Instructions/Labs/LAB[MB-230]_M03Lab02_AgentExpProfile.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Agent experience profiles'
-    module: 'Module 3: Customer Service workspaces'
+  title: 'Lab: Agent experience profiles'
+  module: 'Module 3: Customer Service workspaces'
+  description: You are a customer service manager at City Power & Light who has been tasked with configuring the agent experience profiles for Customer Service workspace. In this lab, you will configure a new profile. This exercise should take approximately 15 minutes to complete.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab – Agent experience profiles

--- a/Instructions/Labs/LAB[MB-230]_M04Lab01_Configure_Customer_Service_Scheduling.md
+++ b/Instructions/Labs/LAB[MB-230]_M04Lab01_Configure_Customer_Service_Scheduling.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Configure Customer Service Scheduling'
-    module: 'Module 4: Implement routing and scheduling'
+  title: 'Lab: Configure Customer Service Scheduling'
+  module: 'Module 4: Implement routing and scheduling'
+  description: In this task you will create new contact records.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab - Configure Customer Service Scheduling

--- a/Instructions/Labs/LAB[MB-230]_M04Lab02_Define_Services.md
+++ b/Instructions/Labs/LAB[MB-230]_M04Lab02_Define_Services.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Define Services'
-    module: 'Module 4: Implement routing and scheduling'
+  title: 'Lab: Define Services'
+  module: 'Module 4: Implement routing and scheduling'
+  description: In this task you will create an oil change service.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab - Define services

--- a/Instructions/Labs/LAB[MB-230]_M06Lab01_Create_Survey.md
+++ b/Instructions/Labs/LAB[MB-230]_M06Lab01_Create_Survey.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab: Create survey'
-    module: 'Module 6: Customer Voice'
+  title: 'Lab: Create survey'
+  module: 'Module 6: Customer Voice'
+  description: In this exercise, you will create an email template and send the survey by email.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 6 – Customer Voice


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 12

- `Instructions/Labs/LAB[MB-230]_M00Lab00_Dynamics_365_Labs.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-230]_M01Lab01_Creating_Cases.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M01Lab02_Creating_Queues.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M01Lab03_Resolving_Cases.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M01Lab04_Route_Cases.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M02Lab01_Entitlements_and_Templates.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M02Lab02_Create_knowledge_articles.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-230]_M03Lab01_Customer_Service_Workspace.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M03Lab02_AgentExpProfile.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M04Lab01_Configure_Customer_Service_Scheduling.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M04Lab02_Define_Services.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-230]_M06Lab01_Create_Survey.md` (description,duration,level,islab)
